### PR TITLE
fix: read cli version from package.json instead of hardcoding

### DIFF
--- a/CLI/src/index.ts
+++ b/CLI/src/index.ts
@@ -9,6 +9,7 @@
 
 import { Command } from 'commander';
 import dotenv from 'dotenv';
+import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
@@ -24,6 +25,11 @@ import { setStubMode } from './core/anthropic.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
+
+// Read version from package.json to avoid hardcoding
+const packageJsonPath = path.join(__dirname, '..', 'package.json');
+const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
+const CLI_VERSION: string = packageJson.version;
 
 // Load environment variables
 // First try CLI directory, then current working directory
@@ -43,7 +49,7 @@ const program = new Command();
 program
   .name('appfactory')
   .description('Generate store-ready Expo React Native apps using Claude AI')
-  .version('1.0.0')
+  .version(CLI_VERSION)
   .option('--json', 'Output all results as JSON (for CI/scripting)')
   .option('--debug', 'Enable debug logging')
   .option('--stub', 'Enable stub mode for testing (no API calls)')


### PR DESCRIPTION
## What
- CLI `--version` flag now reads from `CLI/package.json` instead of hardcoding `'1.0.0'`

## Why
The CLI version was hardcoded as `'1.0.0'` in the commander `.version()` call on line 46 of `CLI/src/index.ts`. This means `appfactory --version` would always report `1.0.0` regardless of the actual version in `package.json` (currently `1.0.0`, but would drift on any version bump).

Reading from `package.json` at startup is the standard pattern (used by commander's own docs) and ensures the reported version always matches the package.

## Tested
- `npx tsc --noEmit` passes (CLI type-checks clean)
- All 252 vitest tests passing
- Lint-staged + commitlint hooks pass