### PR TITLE
fix: resolve timingSafeEqual infinite recursion + correct repo URLs

### DIFF
--- a/plugins/repo-mode-launch/lib/hashing.ts
+++ b/plugins/repo-mode-launch/lib/hashing.ts
@@ -3,7 +3,7 @@
  * Uses SHA256 for all cryptographic hashing
  */
 
-import { createHash, timingSafeEqual } from 'crypto';
+import { createHash, timingSafeEqual as cryptoTimingSafeEqual } from 'crypto';
 
 /**
  * Compute SHA256 hash of a string
@@ -117,5 +117,5 @@ export function timingSafeEqual(a: string, b: string): boolean {
   const bufB = Buffer.from(b, 'utf8');
 
   // Use crypto.timingSafeEqual for constant-time comparison
-  return timingSafeEqual(bufA, bufB);
+  return cryptoTimingSafeEqual(bufA, bufB);
 }


### PR DESCRIPTION
## What
1. **Fix critical timingSafeEqual infinite recursion bug** in plugins/repo-mode-launch/lib/hashing.ts - the exported function shadows the crypto import, causing stack overflow at runtime. Renamed import to cryptoTimingSafeEqual.

2. **Fix repository URL mismatch** in package.json - repository.url and bugs.url pointed to 0xAxiom/AppFactory (fork) instead of MeltedMindz/AppFactory (canonical).

## Why
- The recursion bug will crash any code path that calls timingSafeEqual for hash comparison (security-critical)
- URL mismatch causes npm metadata to point to the wrong repo

## Tested
- ESLint + Prettier pass (lint-staged)
- Verified import rename correctly resolves to Node.js crypto.timingSafeEqual