### PR TITLE
Fix: await in constructor bug + centralize partner key

### DIFF
--- a/dapp-factory/pipeline/prompt_enforcer.ts
+++ b/dapp-factory/pipeline/prompt_enforcer.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as crypto from 'crypto';
+import { APP_FACTORY_PARTNER_KEY } from '../constants/partner';
 
 /**
  * Web3 Factory Prompt-Driven Execution Framework
@@ -242,12 +243,9 @@ ${Object.entries(report.validation_results)
           const feeRouting = JSON.parse(
             fs.readFileSync(feeRoutingPath, 'utf-8')
           );
-          if (
-            feeRouting.partner_key !==
-            'FDYcVLxHkekUFz4M29hCuBH3vbf1aLm62GEFZxLFdGE7'
-          ) {
+          if (feeRouting.partner_key !== APP_FACTORY_PARTNER_KEY) {
             validationErrors.push(
-              'Partner key must be exactly FDYcVLxHkekUFz4M29hCuBH3vbf1aLm62GEFZxLFdGE7'
+              `Partner key must be exactly ${APP_FACTORY_PARTNER_KEY}`
             );
           }
           if (
@@ -274,8 +272,7 @@ ${Object.entries(report.validation_results)
           );
           if (
             !bagsConfig.fee_routing ||
-            bagsConfig.fee_routing.partner_key !==
-              'FDYcVLxHkekUFz4M29hCuBH3vbf1aLm62GEFZxLFdGE7'
+            bagsConfig.fee_routing.partner_key !== APP_FACTORY_PARTNER_KEY
           ) {
             validationErrors.push(
               'Bags config must include hardcoded partner key'

--- a/dapp-factory/pipeline/web3_pipeline.ts
+++ b/dapp-factory/pipeline/web3_pipeline.ts
@@ -1,6 +1,8 @@
+import * as crypto from 'crypto';
 import * as fs from 'fs';
 import * as path from 'path';
 import { PromptEnforcer, executeStageWithPrompt } from './prompt_enforcer';
+import { APP_FACTORY_PARTNER_KEY, FEE_SPLIT } from '../constants/partner';
 
 /**
  * Web3 Factory Main Pipeline Controller
@@ -27,7 +29,6 @@ export class Web3Pipeline {
 
     // Generate run ID if not provided
     const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
-    const crypto = await import('crypto');
     const ideaHash = crypto
       .createHash('md5')
       .update(config.idea)
@@ -281,7 +282,7 @@ This application uses a hybrid architecture where:
         const feeRouting = {
           creator_share: 0.75,
           partner_share: 0.25,
-          partner_key: 'FDYcVLxHkekUFz4M29hCuBH3vbf1aLm62GEFZxLFdGE7',
+          partner_key: APP_FACTORY_PARTNER_KEY,
         };
 
         const tokenEconomics = `# Token Economics
@@ -538,7 +539,7 @@ The economic model ensures sustainable value creation:
           fee_routing: {
             creator_share: 0.75,
             partner_share: 0.25,
-            partner_key: 'FDYcVLxHkekUFz4M29hCuBH3vbf1aLm62GEFZxLFdGE7',
+            partner_key: APP_FACTORY_PARTNER_KEY,
           },
           token_params: {
             name: 'Example Token',

--- a/package.json
+++ b/package.json
@@ -59,10 +59,10 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/0xAxiom/AppFactory.git"
+    "url": "https://github.com/MeltedMindz/AppFactory.git"
   },
   "bugs": {
-    "url": "https://github.com/0xAxiom/AppFactory/issues"
+    "url": "https://github.com/MeltedMindz/AppFactory/issues"
   },
   "homepage": "https://github.com/MeltedMindz/AppFactory#readme",
   "engines": {


### PR DESCRIPTION
## What
- Fix critical runtime bug: `await import('crypto')` in `Web3Pipeline` constructor. Constructors cannot be async in JS/TS, so `await` returns a pending Promise, causing `crypto.createHash` to throw and breaking `runId` generation.
- Centralize hardcoded partner key to use `APP_FACTORY_PARTNER_KEY` from `constants/partner.ts` instead of duplicating the literal string across files.
- Fix repository URL mismatch in `package.json` (`0xAxiom` -> `MeltedMindz`).

## Why
- The await bug breaks the entire Web3 pipeline at runtime.
- Partner key duplication risks inconsistency during rotation.
- URL mismatch confuses contributors and tooling.

## Tested
- All 252 tests pass
- ESLint + Prettier pass via lint-staged