### PR TITLE
fix(core): resolve timingSafeEqual infinite recursion bug

### DIFF
--- a/plugins/repo-mode-launch/lib/hashing.ts
+++ b/plugins/repo-mode-launch/lib/hashing.ts
@@ -3,7 +3,7 @@
  * Uses SHA256 for all cryptographic hashing
  */
 
-import { createHash, timingSafeEqual } from 'crypto';
+import { createHash, timingSafeEqual as cryptoTimingSafeEqual } from 'crypto';
 
 /**
  * Compute SHA256 hash of a string
@@ -117,5 +117,5 @@ export function timingSafeEqual(a: string, b: string): boolean {
   const bufB = Buffer.from(b, 'utf8');
 
   // Use crypto.timingSafeEqual for constant-time comparison
-  return timingSafeEqual(bufA, bufB);
+  return cryptoTimingSafeEqual(bufA, bufB);
 }


### PR DESCRIPTION
## What
Fix infinite recursion bug in `plugins/repo-mode-launch/lib/hashing.ts` where the exported `timingSafeEqual` function shadows the imported `crypto.timingSafeEqual`, causing a stack overflow when called.

## Why
The exported function calls itself recursively instead of the Node.js crypto module's `timingSafeEqual`. Any code path that invokes this function (e.g., webhook signature verification) would crash with a stack overflow.

## Fix
Renamed the import to `cryptoTimingSafeEqual` to avoid the name collision. The exported function now correctly delegates to the crypto module.

## Tested
- Verified the import alias resolves correctly
- Lint and format checks pass (husky pre-commit hooks)