### PR TITLE
fix(core): align repository and bugs urls to meltedmindz org

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,10 +59,10 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/0xAxiom/AppFactory.git"
+    "url": "https://github.com/MeltedMindz/AppFactory.git"
   },
   "bugs": {
-    "url": "https://github.com/0xAxiom/AppFactory/issues"
+    "url": "https://github.com/MeltedMindz/AppFactory/issues"
   },
   "homepage": "https://github.com/MeltedMindz/AppFactory#readme",
   "engines": {


### PR DESCRIPTION
## What
Fix mismatched URLs in package.json where `repository.url` and `bugs.url` pointed to `0xAxiom/AppFactory` (fork) instead of the canonical `MeltedMindz/AppFactory`.

## Why
npm metadata and GitHub links should point to the upstream org, not the fork. This affects `npm bugs`, `npm repo`, and package registry metadata.

## Tested
- Prettier format check passes
- All URLs now consistently reference MeltedMindz/AppFactory