### PR TITLE
fix(claw-pipeline): add missing functionname to interface and fix unsafe error access

### DIFF
--- a/claw-pipeline/base-wallet-xray/app/api/analyze/route.ts
+++ b/claw-pipeline/base-wallet-xray/app/api/analyze/route.ts
@@ -8,6 +8,7 @@ interface EtherscanTx {
   gasUsed: string;
   gasPrice: string;
   input: string;
+  functionName?: string;
   timeStamp: string;
   isError: string;
 }
@@ -173,6 +174,7 @@ export async function GET(req: NextRequest) {
       recentTokens,
     });
   } catch (e: unknown) {
-    return NextResponse.json({ error: e.message }, { status: 500 });
+    const message = e instanceof Error ? e.message : 'Unknown error';
+    return NextResponse.json({ error: message }, { status: 500 });
   }
 }


### PR DESCRIPTION
## What
- Added missing `functionName` optional property to `EtherscanTx` interface in `base-wallet-xray/app/api/analyze/route.ts`
- Fixed unsafe property access on `unknown` error type in catch block

## Why
- `functionName` is accessed on line 132 (`tx.functionName?.split('(')[0]`) but was not declared in the interface, causing a TypeScript compilation error
- The catch block types `e` as `unknown` but directly accesses `e.message`, which is a TypeScript error since `unknown` has no properties

## Changes
- Added `functionName?: string` to the `EtherscanTx` interface
- Replaced `e.message` with `e instanceof Error ? e.message : 'Unknown error'` for proper type narrowing

## Tested
- Verified changes pass lint and prettier checks (enforced by pre-commit hooks)