### PR TITLE
Fix: command injection in executeScript

### DIFF
--- a/CLI/src/core/stages.ts
+++ b/CLI/src/core/stages.ts
@@ -10,10 +10,10 @@ import { readFile, readJson, writeFile, writeJson, fileExists } from './io.js';
 import { getTemplatePath, getSchemaPath, getStandardsPath } from './paths.js';
 import { extractJson, callClaude } from './anthropic.js';
 import { logger } from './logging.js';
-import { exec } from 'child_process';
+import { execFile } from 'child_process';
 import { promisify } from 'util';
 
-const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
 
 // Stage definition
 export interface StageDefinition {
@@ -471,8 +471,7 @@ export async function executeScript(
   logger.scriptStart(scriptName);
 
   try {
-    const command = `bash "${scriptPath}" ${args.map((a) => `"${a}"`).join(' ')}`;
-    const { stdout, stderr } = await execAsync(command, {
+    const { stdout, stderr } = await execFileAsync('bash', [scriptPath, ...args], {
       cwd,
       timeout: 120000, // 2 minute timeout
     });


### PR DESCRIPTION
## What
Replace `exec()` with `execFile()` in `CLI/src/core/stages.ts` to prevent command injection via shell metacharacters in script arguments.

## Why
The previous implementation used string interpolation to build a shell command. Double-quoting does not prevent injection if args contain quotes, $, or backticks. Using `execFile()` bypasses the shell entirely, passing args directly to the process.

## Tested
- All 252 tests pass
- Lint and prettier pass