### PR TITLE
fix: update legacy meltedmindz org urls to 0xaxiom

### DIFF
--- a/.claude/skills/appfactory-builder/SKILL.md
+++ b/.claude/skills/appfactory-builder/SKILL.md
@@ -7,7 +7,7 @@ description: Build and deploy production apps using AppFactory's 7 pipelines (we
 
 Build and deploy production apps in minutes using AppFactory's 7 pipelines. No setup required — describe what you want, get a live URL.
 
-**Repo:** [github.com/MeltedMindz/AppFactory](https://github.com/MeltedMindz/AppFactory)
+**Repo:** [github.com/0xAxiom/AppFactory](https://github.com/0xAxiom/AppFactory)
 **Showcase:** [factoryapp.dev](https://factoryapp.dev)
 
 ---
@@ -31,7 +31,7 @@ Build and deploy production apps in minutes using AppFactory's 7 pipelines. No s
 ### 1. Clone the Repo
 
 ```bash
-git clone https://github.com/MeltedMindz/AppFactory.git
+git clone https://github.com/0xAxiom/AppFactory.git
 cd AppFactory
 ```
 
@@ -188,7 +188,7 @@ Each pipeline has its own `CLAUDE.md` constitution. To improve a pipeline:
 
 ### Report Issues
 
-File issues at [github.com/MeltedMindz/AppFactory/issues](https://github.com/MeltedMindz/AppFactory/issues) for:
+File issues at [github.com/0xAxiom/AppFactory/issues](https://github.com/0xAxiom/AppFactory/issues) for:
 
 - Pipeline bugs or failures
 - Missing features
@@ -244,7 +244,7 @@ This adds periodic checks to:
 
 ## Links
 
-- **Repo:** [github.com/MeltedMindz/AppFactory](https://github.com/MeltedMindz/AppFactory)
+- **Repo:** [github.com/0xAxiom/AppFactory](https://github.com/0xAxiom/AppFactory)
 - **Showcase:** [factoryapp.dev](https://factoryapp.dev)
 - **Token Launchpad:** [appfactory.fun](https://appfactory.fun)
 - **$FACTORY Token:** [Jupiter](https://jup.ag/swap?buy=BkSbFrDMkfkoG4NDUwadEGeQgVwoXkR3F3P1MPUnBAGS)

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -10,17 +10,17 @@
 
 ### Questions and Discussions
 
-- Open a [Discussion](https://github.com/MeltedMindz/AppFactory/discussions) for questions
+- Open a [Discussion](https://github.com/0xAxiom/AppFactory/discussions) for questions
 - Check existing discussions for answers
 
 ### Bug Reports
 
-- Use the [Bug Report template](https://github.com/MeltedMindz/AppFactory/issues/new?template=bug_report.yml)
+- Use the [Bug Report template](https://github.com/0xAxiom/AppFactory/issues/new?template=bug_report.yml)
 - Include reproduction steps and relevant logs
 
 ### Feature Requests
 
-- Use the [Feature Request template](https://github.com/MeltedMindz/AppFactory/issues/new?template=feature_request.yml)
+- Use the [Feature Request template](https://github.com/0xAxiom/AppFactory/issues/new?template=feature_request.yml)
 - Describe the use case and expected behavior
 
 ### Security Issues

--- a/HEARTBEAT.md
+++ b/HEARTBEAT.md
@@ -55,7 +55,7 @@ If there are new commits:
 - Pull updates: `git pull origin main`
 - Check for new pipelines or features
 - Try building with any updated pipeline
-- Report bugs to github.com/MeltedMindz/AppFactory/issues
+- Report bugs to github.com/0xAxiom/AppFactory/issues
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -800,8 +800,8 @@ MIT License - Free to use, modify, and share.
 ---
 
 <p align="center">
-  <a href="https://star-history.com/#MeltedMindz/AppFactory&Date">
-    <img src="https://api.star-history.com/svg?repos=MeltedMindz/AppFactory&type=Date" alt="Star History Chart" width="600" />
+  <a href="https://star-history.com/#0xAxiom/AppFactory&Date">
+    <img src="https://api.star-history.com/svg?repos=0xAxiom/AppFactory&type=Date" alt="Star History Chart" width="600" />
   </a>
 </p>
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -112,11 +112,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Simplified pipeline architecture
 
-[Unreleased]: https://github.com/MeltedMindz/AppFactory/compare/v11.0.0...HEAD
-[11.0.0]: https://github.com/MeltedMindz/AppFactory/compare/v10.0.0...v11.0.0
-[10.0.0]: https://github.com/MeltedMindz/AppFactory/compare/v9.0.0...v10.0.0
-[9.0.0]: https://github.com/MeltedMindz/AppFactory/compare/v8.0.0...v9.0.0
-[8.0.0]: https://github.com/MeltedMindz/AppFactory/compare/v7.0.0...v8.0.0
-[7.0.0]: https://github.com/MeltedMindz/AppFactory/compare/v5.0.0...v7.0.0
-[5.0.0]: https://github.com/MeltedMindz/AppFactory/compare/v4.0.0...v5.0.0
-[4.0.0]: https://github.com/MeltedMindz/AppFactory/releases/tag/v4.0.0
+[Unreleased]: https://github.com/0xAxiom/AppFactory/compare/v11.0.0...HEAD
+[11.0.0]: https://github.com/0xAxiom/AppFactory/compare/v10.0.0...v11.0.0
+[10.0.0]: https://github.com/0xAxiom/AppFactory/compare/v9.0.0...v10.0.0
+[9.0.0]: https://github.com/0xAxiom/AppFactory/compare/v8.0.0...v9.0.0
+[8.0.0]: https://github.com/0xAxiom/AppFactory/compare/v7.0.0...v8.0.0
+[7.0.0]: https://github.com/0xAxiom/AppFactory/compare/v5.0.0...v7.0.0
+[5.0.0]: https://github.com/0xAxiom/AppFactory/compare/v4.0.0...v5.0.0
+[4.0.0]: https://github.com/0xAxiom/AppFactory/releases/tag/v4.0.0

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -39,7 +39,7 @@
 ### Step 1: Clone the Repository
 
 ```bash
-git clone https://github.com/MeltedMindz/AppFactory.git
+git clone https://github.com/0xAxiom/AppFactory.git
 cd AppFactory
 ```
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -158,7 +158,7 @@ App Factory aims to be the most comprehensive AI-powered application generation 
 
 ### GitHub Issues
 
-1. Go to [GitHub Issues](https://github.com/MeltedMindz/AppFactory/issues)
+1. Go to [GitHub Issues](https://github.com/0xAxiom/AppFactory/issues)
 2. Check if feature already requested
 3. Create new issue with template:
    - **Title**: `[Feature Request] Brief description`

--- a/docs/guides/sync-machines.md
+++ b/docs/guides/sync-machines.md
@@ -35,7 +35,7 @@ git push          # Push to GitHub
 Clone the repository:
 
 ```bash
-git clone https://github.com/MeltedMindz/AppFactory.git
+git clone https://github.com/0xAxiom/AppFactory.git
 cd AppFactory
 npm ci            # Install dependencies
 ```

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   "bugs": {
     "url": "https://github.com/0xAxiom/AppFactory/issues"
   },
-  "homepage": "https://github.com/MeltedMindz/AppFactory#readme",
+  "homepage": "https://github.com/0xAxiom/AppFactory#readme",
   "engines": {
     "node": ">=18.0.0"
   },


### PR DESCRIPTION
## What
Updates all remaining `MeltedMindz/AppFactory` URLs to `0xAxiom/AppFactory` across 9 files.

## Why
The repo was transferred from MeltedMindz to 0xAxiom. While GitHub redirects work, canonical URLs prevent confusion for contributors and ensure tools (npm, IDEs, CI) resolve correctly.

## Files Changed
- `package.json` - homepage URL
- `README.md` - star-history badge
- `SKILL.md` - clone/PR/issues URLs
- `HEARTBEAT.md` - issues/PR references  
- `docs/CHANGELOG.md` - version comparison links
- `docs/GETTING_STARTED.md` - clone URL
- `docs/ROADMAP.md` - issues link
- `docs/guides/sync-machines.md` - clone URL
- `.github/SUPPORT.md` - discussions/issues links
- `.claude/skills/appfactory-builder/SKILL.md` - repo/clone/issues URLs

## Tested
- Lint-staged + commitlint pass
- All URLs verified to resolve correctly