### PR TITLE
fix: use non-greedy json extraction with parse validation

### DIFF
--- a/CLI/src/core/anthropic.ts
+++ b/CLI/src/core/anthropic.ts
@@ -88,9 +88,21 @@ export function extractJson(content: string): string {
   }
 
   // Try to find JSON object or array
-  const jsonMatch = content.match(/(\{[\s\S]*\}|\[[\s\S]*\])/);
+  // Use non-greedy matching to avoid spanning across multiple JSON blocks
+  // (greedy [\s\S]* would match from first { to LAST }, grabbing too much)
+  const jsonMatch = content.match(/(\{[\s\S]*?\}|\[[\s\S]*?\])/);
   if (jsonMatch) {
-    return jsonMatch[1].trim();
+    // Validate it's actually parseable JSON; if not, try greedy as fallback
+    try {
+      JSON.parse(jsonMatch[1]);
+      return jsonMatch[1].trim();
+    } catch {
+      // Non-greedy grabbed too little (nested braces); fall back to greedy
+      const greedyMatch = content.match(/(\{[\s\S]*\}|\[[\s\S]*\])/);
+      if (greedyMatch) {
+        return greedyMatch[1].trim();
+      }
+    }
   }
 
   // Return as-is


### PR DESCRIPTION
## What
The `extractJson` function in `CLI/src/core/anthropic.ts` uses a greedy regex to find JSON in Claude responses. Greedy `[\s\S]*` matches from the first `{` to the last `}`, grabbing too much when responses contain multiple JSON blocks.

## Fix
- Non-greedy match first for smallest valid span
- Validate with `JSON.parse()`
- Greedy fallback for deeply nested objects

## Tested
- Passes lint-staged, eslint, prettier