### PR TITLE
fix: remove await from constructor in web3pipeline

### DIFF
--- a/dapp-factory/pipeline/web3_pipeline.ts
+++ b/dapp-factory/pipeline/web3_pipeline.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
+import * as crypto from 'crypto';
 import { PromptEnforcer, executeStageWithPrompt } from './prompt_enforcer';
 
 /**
@@ -27,7 +28,6 @@ export class Web3Pipeline {
 
     // Generate run ID if not provided
     const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
-    const crypto = await import('crypto');
     const ideaHash = crypto
       .createHash('md5')
       .update(config.idea)


### PR DESCRIPTION
**What:** Fixes compile-time error in Web3Pipeline constructor

**Problem:** Constructor was using `await import('crypto')` which is invalid syntax since constructors cannot be async.

**Solution:** 
- Moved crypto import to top-level module import
- Removed async import from constructor
- Maintains identical functionality for crypto hash generation

**Tested:** Code compiles without errors and maintains same behavior.

**Priority:** High - this is a compile-time bug that prevents the pipeline from running.