### PR TITLE
fix: correct repository url in readme installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ App Factory turns your ideas into real, working products. No coding experience r
 Install as a skill in your OpenClaw environment:
 
 ```bash
-npx skills add 0xAxiom/AppFactory
+npx skills add MeltedMindz/AppFactory
 ```
 
 ---


### PR DESCRIPTION
What: Fix repository URL inconsistency in README.md

Why: The README referenced 0xAxiom/AppFactory but package.json shows MeltedMindz/AppFactory as the canonical repository URL. This inconsistency could confuse users trying to install via skills.

Tested: Verified the change aligns with package.json repository field