### PR TITLE
fix: remove await from constructor in web3_pipeline.ts

### DIFF
--- a/.github/rebuild-trigger.txt
+++ b/.github/rebuild-trigger.txt
@@ -1,0 +1,1 @@
+# CI rebuild trigger

--- a/dapp-factory/pipeline/web3_pipeline.ts
+++ b/dapp-factory/pipeline/web3_pipeline.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
+import * as crypto from 'crypto';
 import { PromptEnforcer, executeStageWithPrompt } from './prompt_enforcer';
 
 /**
@@ -27,7 +28,6 @@ export class Web3Pipeline {
 
     // Generate run ID if not provided
     const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
-    const crypto = await import('crypto');
     const ideaHash = crypto
       .createHash('md5')
       .update(config.idea)


### PR DESCRIPTION
What: Fix critical syntax error in Web3Pipeline constructor

Why: The constructor was using `await import('crypto')` which is invalid JavaScript - constructors cannot be async. This would cause runtime errors when the Web3Pipeline class is instantiated.

How: Move crypto import to top-level imports instead of dynamic import

Tested: TypeScript compilation now passes without errors