### PR TITLE
fix: remove unused private_key requirement from environment validation

### DIFF
--- a/dapp-factory/scripts/validate_environment.ts
+++ b/dapp-factory/scripts/validate_environment.ts
@@ -41,7 +41,6 @@ function validateEnvironment(): ValidationResult {
     'SOLANA_RPC_URL',
     'SOLANA_NETWORK',
     'CREATOR_WALLET_ADDRESS',
-    'PRIVATE_KEY',
   ];
 
   // Check required variables exist
@@ -89,9 +88,14 @@ function validateEnvironment(): ValidationResult {
     );
   }
 
+  // Note: PRIVATE_KEY is not required by AppFactory infrastructure.
+  // If you need to add signing functionality, ensure proper key management
+  // practices: dedicated hot wallet, minimal funds, secure storage.
   const privateKey = process.env.PRIVATE_KEY;
   if (privateKey && !validateBase58Key(privateKey)) {
-    errors.push('PRIVATE_KEY appears to be invalid Base58 format');
+    warnings.push(
+      'PRIVATE_KEY is set but appears to be invalid Base58 format. Consider removing if not needed.'
+    );
   }
 
   // Check for common misconfigurations


### PR DESCRIPTION
What: Remove PRIVATE_KEY from required environment variables in validation script

Why: Security audit identified that PRIVATE_KEY was required but never used, creating unnecessary security risk by encouraging users to store private keys in .env files

Changes:
- Removed PRIVATE_KEY from required variables list  
- Convert validation to optional warning instead of required error
- Added security guidance comment about proper key management practices
- Prevents accidental private key exposure when functionality is not needed

Security Impact: Reduces attack surface by not requiring sensitive credentials that are not utilized by the codebase

Tested: Validation script runs without errors, warnings appropriately surface when PRIVATE_KEY is present