### PR TITLE
fix: resolve async constructor syntax error in web3 pipeline

### DIFF
--- a/dapp-factory/pipeline/web3_pipeline.ts
+++ b/dapp-factory/pipeline/web3_pipeline.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
+import * as crypto from 'crypto';
 import { PromptEnforcer, executeStageWithPrompt } from './prompt_enforcer';
 
 /**
@@ -27,7 +28,6 @@ export class Web3Pipeline {
 
     // Generate run ID if not provided
     const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
-    const crypto = await import('crypto');
     const ideaHash = crypto
       .createHash('md5')
       .update(config.idea)


### PR DESCRIPTION
## What
Fixes a critical runtime syntax error in the dApp factory pipeline that would prevent execution.

## Why  
JavaScript constructors cannot be async. The Web3Pipeline constructor was using:
```typescript
const crypto = await import('crypto');  // ❌ SyntaxError in constructor
```

This would throw a syntax error at runtime when trying to instantiate the Web3Pipeline class.

## Fix
- Move crypto import from dynamic import to top-level import
- Remove await from constructor 
- No functional changes - just fixes the syntax error

## Before/After
```typescript
// Before (broken)
constructor(config: Web3PipelineConfig) {
  const crypto = await import('crypto');  // ❌ Runtime error
}

// After (fixed)
import * as crypto from 'crypto';
constructor(config: Web3PipelineConfig) {
  // No await needed
}
```

## Impact
- ✅ Fixes critical runtime bug in dapp-factory pipeline
- ✅ No API changes - purely an internal fix
- ✅ TypeScript compilation now passes cleanly
- ✅ Identified by automated security review (Forge + Cipher agents)

## Testing
- TypeScript compilation passes without errors
- No functional changes to the pipeline logic