### PR TITLE
fix: resolve high-severity security vulnerability in flatted package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4239,9 +4239,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.1.tgz",
+      "integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
       "dev": true,
       "license": "ISC"
     },


### PR DESCRIPTION
What: Fix high-severity DoS vulnerability in flatted package by running npm audit fix

Why: The flatted package had a vulnerability that could lead to unbounded recursion DoS in the parse() revive phase (GHSA-25h7-pfq9-p65f)

Tested: npm audit now reports 0 vulnerabilities

Changes: Updated package-lock.json to use secure version of flatted dependency