### PR TITLE
fix: resolve high severity flatted vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4239,9 +4239,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },


### PR DESCRIPTION
What: Fix high severity vulnerability in flatted package

Why: npm audit detected flatted <=3.4.1 has DoS and prototype pollution vulnerabilities (GHSA-25h7-pfq9-p65f, GHSA-rf6f-7fwh-wjgh)

Tested: npm audit shows 0 vulnerabilities after fix