### PR TITLE
fix: replace illegal await-in-constructor with static crypto import (Web3 Factory broken)

### DIFF
--- a/dapp-factory/pipeline/web3_pipeline.ts
+++ b/dapp-factory/pipeline/web3_pipeline.ts
@@ -1,3 +1,4 @@
+import * as crypto from 'crypto';
 import * as fs from 'fs';
 import * as path from 'path';
 import { PromptEnforcer, executeStageWithPrompt } from './prompt_enforcer';
@@ -27,7 +28,6 @@ export class Web3Pipeline {
 
     // Generate run ID if not provided
     const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
-    const crypto = await import('crypto');
     const ideaHash = crypto
       .createHash('md5')
       .update(config.idea)


### PR DESCRIPTION
## What

Fix a `SyntaxError` that prevents the Web3 Factory (`web3 idea <IDEA>`) from starting.

## Root Cause

`dapp-factory/pipeline/web3_pipeline.ts` uses `await import('crypto')` inside the `Web3Pipeline` class constructor:

```typescript
// ❌ Broken — constructors are synchronous, await is illegal here
constructor(config: Web3PipelineConfig) {
  ...
  const crypto = await import('crypto');   // SyntaxError at runtime
  const ideaHash = crypto.createHash('md5')...
```

At runtime Node.js throws:
```
SyntaxError: Unexpected reserved word
```
This crashes the process before any pipeline stage runs.

**Why it wasn't caught by TypeScript:** `dapp-factory/tsconfig.json` excludes `pipeline/**` from compilation, so the compiler never saw this file.

## Fix

Replace the illegal dynamic import with a static import at the top of the file — consistent with `prompt_enforcer.ts`, which already uses `import * as crypto from 'crypto'`:

```typescript
// ✅ Fixed
import * as crypto from 'crypto';
...
constructor(config: Web3PipelineConfig) {
  ...
  const ideaHash = crypto.createHash('md5')...
```

No behaviour change. `crypto` is a Node.js built-in; static import is equivalent and synchronous.

## Tested

- Manually verified the constructor no longer throws
- `npm test` — 252/252 tests pass ✅