### PR TITLE
fix: update default claude model to claude-sonnet-4-6

### DIFF
--- a/CLI/src/core/anthropic.test.ts
+++ b/CLI/src/core/anthropic.test.ts
@@ -54,7 +54,7 @@ describe('anthropic module', () => {
 
       const config = loadConfig();
 
-      expect(config.model).toBe('claude-sonnet-4-20250514');
+      expect(config.model).toBe('claude-sonnet-4-6');
       expect(config.maxTokens).toBe(16000);
       expect(config.temperature).toBe(0.3);
     });

--- a/CLI/src/core/anthropic.ts
+++ b/CLI/src/core/anthropic.ts
@@ -16,7 +16,7 @@ export interface AnthropicConfig {
 }
 
 // Default configuration values
-const DEFAULT_MODEL = 'claude-sonnet-4-20250514';
+const DEFAULT_MODEL = 'claude-sonnet-4-6';
 const DEFAULT_MAX_TOKENS = 16000;
 const DEFAULT_TEMPERATURE = 0.3;
 const MAX_RETRIES = 3;

--- a/CLI/src/core/pipeline.ts
+++ b/CLI/src/core/pipeline.ts
@@ -270,7 +270,7 @@ export async function executeRun(config: PipelineConfig = {}): Promise<{
     const manifest = createRunManifest(
       runId,
       'run',
-      config.model || 'claude-sonnet-4-20250514',
+      config.model || 'claude-sonnet-4-6',
       inputsHash
     );
     manifest.run_status = 'in_progress';
@@ -660,7 +660,7 @@ export async function executeDream(
     const manifest = createRunManifest(
       runId,
       'dream',
-      config.model || 'claude-sonnet-4-20250514',
+      config.model || 'claude-sonnet-4-6',
       inputsHash
     );
     manifest.run_status = 'in_progress';

--- a/claw-pipeline/constants/openclaw.ts
+++ b/claw-pipeline/constants/openclaw.ts
@@ -134,7 +134,7 @@ export const MODEL_PROVIDERS = {
   claude: {
     name: 'Claude (Anthropic)',
     envVars: ['ANTHROPIC_API_KEY'],
-    defaultModel: 'claude-sonnet-4-20250514',
+    defaultModel: 'claude-sonnet-4-6',
     description: 'Recommended for complex reasoning and tool use',
   },
   openai: {


### PR DESCRIPTION
## What

Update the hardcoded default Claude model from `claude-sonnet-4-20250514` to `claude-sonnet-4-6` across all four locations where it appears:

| File | Change |
|------|--------|
| `CLI/src/core/anthropic.ts` | `DEFAULT_MODEL` constant |
| `CLI/src/core/pipeline.ts` | Two fallback references in `executeRun()` |
| `claw-pipeline/constants/openclaw.ts` | `MODEL_PROVIDERS.claude.defaultModel` |
| `CLI/src/core/anthropic.test.ts` | Test expectation updated to match |

## Why

`claude-sonnet-4-20250514` is the original Claude 4 Sonnet (May 2025). `claude-sonnet-4-6` is the current generation — better performance and lower latency. PR #237 upgrades the Anthropic SDK but leaves the default model name stale. This is a separate, focused change targeting only the model string.

## Tested

- `npm test` — 252/252 tests pass
- `npm run type-check:cli` — no TypeScript errors

🤖 Generated with [Claude Code](https://claude.ai/claude-code)