### PR TITLE
fix(cli): correct ajv import to resolve TypeScript build error

### DIFF
--- a/CLI/package.json
+++ b/CLI/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.32.0",
-    "ajv": "^8.17.1",
+    "ajv": "^8.20.0",
     "chalk": "^5.3.0",
     "commander": "^12.1.0",
     "dotenv": "^16.4.5",

--- a/CLI/src/core/stages.ts
+++ b/CLI/src/core/stages.ts
@@ -5,7 +5,7 @@
  */
 
 import path from 'path';
-import Ajv from 'ajv';
+import { Ajv } from 'ajv';
 import { readFile, readJson, writeFile, writeJson, fileExists } from './io.js';
 import { getTemplatePath, getSchemaPath, getStandardsPath } from './paths.js';
 import { extractJson, callClaude } from './anthropic.js';
@@ -228,7 +228,7 @@ export function getDreamStages(): StageDefinition[] {
 }
 
 // Schema validation
-const ajv = new Ajv.default({ allErrors: true, strict: false });
+const ajv = new Ajv({ allErrors: true, strict: false });
 
 export function validateAgainstSchema(
   data: unknown,

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.32.0",
-        "ajv": "^8.17.1",
+        "ajv": "^8.20.0",
         "chalk": "^5.3.0",
         "commander": "^12.1.0",
         "dotenv": "^16.4.5",
@@ -101,9 +101,9 @@
       }
     },
     "CLI/node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",


### PR DESCRIPTION
## What

Fixes a TypeScript compilation error in `CLI/src/core/stages.ts` caused by an incorrect AJV import pattern.

**Before:**
```typescript
import Ajv from 'ajv';
// ...
const ajv = new Ajv.default({ allErrors: true, strict: false });
```

**After:**
```typescript
import { Ajv } from 'ajv';
// ...
const ajv = new Ajv({ allErrors: true, strict: false });
```

## Why

The default import `import Ajv from 'ajv'` combined with `new Ajv.default()` caused two TypeScript errors depending on which version of AJV types TypeScript resolved:

1. `Property 'default' does not exist on type` — when resolving against the root workspace `node_modules/ajv` (v6, which has no `strict` option and no `.default` subclass)
2. `This expression is not constructable` — when resolving against `CLI/node_modules/ajv` (v8 with `dist/` built)

`npm run type-check` exited non-zero before this fix; it exits 0 after.

The named import `{ Ajv }` correctly targets the exported class in AJV v8's type declarations (`export declare class Ajv`), removing both errors.

Also bumps `ajv` to `^8.20.0` (latest patch) which ships with a compiled `dist/` directory, ensuring TypeScript resolves AJV v8 types rather than hoisting to the root workspace's AJV v6.

## Tested

- `npm run type-check` passes (exit 0)
- `npm run lint` output unchanged (same 53 warnings, 0 errors)
- No behaviour change at runtime — the named and default imports resolve to the same class in Node.js

🤖 Generated with [Claude Code](https://claude.ai/claude-code)