### PR TITLE
fix(core): remove shell: true from spawn() in ralph checks

### DIFF
--- a/core/src/ralph/checks.ts
+++ b/core/src/ralph/checks.ts
@@ -22,7 +22,6 @@ async function runCommand(
   return new Promise((resolve) => {
     const proc = spawn(command, args, {
       cwd,
-      shell: true,
       stdio: ['pipe', 'pipe', 'pipe'],
     });
 


### PR DESCRIPTION
## What

Removes `shell: true` from the `spawn()` call in `core/src/ralph/checks.ts`.

## Why

`shell: true` enables shell interpretation of the command string, which creates a shell injection vector. If any argument or `cwd` value ever contained shell metacharacters (`;`, `&&`, `$(...)`, etc.), the shell would interpret them.

In this specific function, all callers pass hardcoded commands (`npm`, `npx`) with fixed argument arrays, so shell interpretation provides zero benefit while adding unnecessary risk. Static analysis tools (e.g. the ralph security scanner already present in this repo) correctly flag this pattern.

**Before:**
```typescript
const proc = spawn(command, args, {
  cwd,
  shell: true,   // ← unnecessary, widens attack surface
  stdio: ['pipe', 'pipe', 'pipe'],
});
```

**After:**
```typescript
const proc = spawn(command, args, {
  cwd,
  stdio: ['pipe', 'pipe', 'pipe'],
});
```

## Scope

Single-line change in `core/src/ralph/checks.ts:25`. No behaviour change on Linux/macOS where `npm` and `npx` are directly executable. If Windows support is needed in future, `shell: process.platform === 'win32'` is the idiomatic approach.

## Tested

- `npm run type-check` passes (exit 0)
- `npm run lint` output unchanged

🤖 Generated with [Claude Code](https://claude.ai/claude-code)