### PR TITLE
fix(dapp-factory): remove illegal await in constructor and fix exit code

### DIFF
--- a/dapp-factory/pipeline/web3_pipeline.ts
+++ b/dapp-factory/pipeline/web3_pipeline.ts
@@ -1,3 +1,4 @@
+import * as crypto from 'crypto';
 import * as fs from 'fs';
 import * as path from 'path';
 import { PromptEnforcer, executeStageWithPrompt } from './prompt_enforcer';
@@ -27,7 +28,6 @@ export class Web3Pipeline {
 
     // Generate run ID if not provided
     const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
-    const crypto = await import('crypto');
     const ideaHash = crypto
       .createHash('md5')
       .update(config.idea)

--- a/dapp-factory/web3factory.ts
+++ b/dapp-factory/web3factory.ts
@@ -85,4 +85,7 @@ process.on('uncaughtException', (error) => {
   process.exit(1);
 });
 
-main().catch(console.error);
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## What

Two bugs in `dapp-factory/` that cause runtime failures:

**1. `await` inside a synchronous constructor (guaranteed crash)**

`dapp-factory/pipeline/web3_pipeline.ts` used `await import('crypto')` inside `Web3Pipeline`'s constructor, which is not `async`. This is illegal in TypeScript/JavaScript — constructors cannot `await`. The expression resolves to a `Promise` at runtime, meaning `.createHash()` would be called on a Promise object instead of the `crypto` module, crashing every `new Web3Pipeline(...)` call.

**Fix:** Add a static top-level `import * as crypto from 'crypto'` (Node.js built-in, no dynamic load needed) and remove the dynamic import line.

**2. `main().catch(console.error)` swallows the exit code**

`dapp-factory/web3factory.ts` ended with `main().catch(console.error)`, which logs the error but exits with code `0`. Any caller (CI, shell scripts) would see success even on failure.

**Fix:** Changed to `main().catch(err => { console.error(err); process.exit(1); })`.

## Why

- **Bug 1** causes `new Web3Pipeline()` to throw a TypeError on every invocation — the dApp pipeline can't start at all.
- **Bug 2** means broken runs are invisible to CI and callers.

## Tested

- `dapp-factory/` TypeScript compiles without errors after the import change.
- Lint and format pass (verified via pre-commit hooks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)