### PR TITLE
fix(cli): surface swallowed errors in locks module

### DIFF
--- a/CLI/src/core/locks.ts
+++ b/CLI/src/core/locks.ts
@@ -59,13 +59,13 @@ export function acquireLock(runId: string, command: string): boolean {
       // Stale lock - process is dead, remove it
       logger.warn(`Removing stale lock from dead process ${lockInfo.pid}`);
       fs.unlinkSync(lockPath);
-    } catch {
+    } catch (err) {
       // Corrupted lock file, remove it
-      logger.warn('Removing corrupted lock file');
+      logger.warn(`Removing corrupted lock file: ${err}`);
       try {
         fs.unlinkSync(lockPath);
-      } catch {
-        // Ignore
+      } catch (unlinkErr) {
+        logger.warn(`Failed to remove corrupted lock file: ${unlinkErr}`);
       }
     }
   }
@@ -115,8 +115,8 @@ export function releaseLock(): void {
         logger.debug('Lock released');
       }
     }
-  } catch {
-    // Ignore errors during cleanup
+  } catch (err) {
+    logger.warn(`Failed to release lock during cleanup: ${err}`);
   }
 }
 
@@ -131,8 +131,8 @@ export function getLockInfo(): LockInfo | null {
       const lockContent = fs.readFileSync(lockPath, 'utf-8');
       return JSON.parse(lockContent) as LockInfo;
     }
-  } catch {
-    // Ignore
+  } catch (err) {
+    logger.warn(`Failed to read lock file: ${err}`);
   }
 
   return null;


### PR DESCRIPTION
## What

`CLI/src/core/locks.ts` had three silent `catch {}` blocks where errors were swallowed with no log output:

1. **`acquireLock` — corrupt lock unlink failure**: The outer `catch` logged *"Removing corrupted lock file"* but if the subsequent `fs.unlinkSync` also failed, the inner `catch {}` was completely silent. A lock that can't be removed stays in place and blocks future runs with no explanation.

2. **`releaseLock` — all errors**: The entire `try` block was wrapped in `catch { // Ignore errors during cleanup }`. If the lock file is corrupted at release time, the lock is never removed and the next run will either block or have to force-release it — with no log entry to explain why.

3. **`getLockInfo` — read/parse errors**: `catch { // Ignore }` made a corrupted lock file return `null`, indistinguishable from "no lock exists". Callers can't tell the difference.

## Fix

Replace each `catch {}` / `catch { // Ignore }` with `catch (err) { logger.warn(...) }` so the error surfaces in the run log. No functional change when things work correctly.

## Why

Silent failures in the locking layer lead to ghost locks and hard-to-diagnose "pipeline won't start" situations. With a warn log, a developer or the user can see what actually went wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)