### PR TITLE
fix(cli): update @anthropic-ai/sdk constraint from ^0.32.0 to ^0.92.0

### DIFF
--- a/CLI/package.json
+++ b/CLI/package.json
@@ -36,7 +36,7 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.32.0",
+    "@anthropic-ai/sdk": "^0.92.0",
     "ajv": "^8.17.1",
     "chalk": "^5.3.0",
     "commander": "^12.1.0",


### PR DESCRIPTION
## What

Update the `@anthropic-ai/sdk` version constraint in `CLI/package.json` from `^0.32.0` to `^0.92.0`.

## Why

The package.json declared `^0.32.0`, but the lock file (and installed version) was `0.92.0`. These two were out of sync in a way that silently breaks new installs:

- `^0.32.0` resolves to `>=0.32.0 <0.33.0` under semver — so a fresh `npm install` would pull in `0.32.1`, a version ~60 releases behind
- The codebase was developed and tested against `0.92.0`, meaning new contributors would get unexpected behaviour or broken API calls

`npm outdated` surfaced this clearly:
```
Package           Current   Wanted   Latest
@anthropic-ai/sdk  0.92.0   0.32.1   0.92.0
```

## Tested

- All 252 existing tests pass (`npm test`)
- No code changes required — the installed SDK version is already correct; only the version range declaration was wrong