### PR TITLE
fix(cli): update default model to claude-sonnet-4-6

### DIFF
--- a/CLI/src/core/anthropic.ts
+++ b/CLI/src/core/anthropic.ts
@@ -16,7 +16,7 @@ export interface AnthropicConfig {
 }
 
 // Default configuration values
-const DEFAULT_MODEL = 'claude-sonnet-4-20250514';
+const DEFAULT_MODEL = 'claude-sonnet-4-6';
 const DEFAULT_MAX_TOKENS = 16000;
 const DEFAULT_TEMPERATURE = 0.3;
 const MAX_RETRIES = 3;


### PR DESCRIPTION
## What

Update `DEFAULT_MODEL` in `CLI/src/core/anthropic.ts` from `claude-sonnet-4-20250514` to `claude-sonnet-4-6`.

## Why

`claude-sonnet-4-20250514` is the dated model alias for Claude Sonnet 4 released in May 2025. As of April 2026, the current generation Sonnet is `claude-sonnet-4-6`, which offers improved reasoning, instruction following, and code generation quality.

Using an outdated model by default means:
- Users get lower quality outputs than the platform can deliver
- The dated alias may eventually be deprecated/retired, breaking the CLI with no obvious error
- New users assume AppFactory is using current capabilities when it is not

Setting `ANTHROPIC_MODEL` env var still overrides this for anyone who needs a specific version.

## Tested

- All 252 existing tests pass (`npm test`)
- Model name is only used at runtime when calling the Anthropic API; no tests mock the model string