### PR TITLE
fix(ci): update stale claude-3 model name in test mock utility

### DIFF
--- a/tests/utils/mock-claude-response.ts
+++ b/tests/utils/mock-claude-response.ts
@@ -58,7 +58,7 @@ export function createMockResponse(
       output_tokens: Math.floor(content.length / 3),
     },
     stopReason: options.stopReason ?? 'end_turn',
-    model: options.model ?? 'claude-3-sonnet-20240229',
+    model: options.model ?? 'claude-sonnet-4-6',
   };
 }
 


### PR DESCRIPTION
## What
Replace `claude-3-sonnet-20240229` with `claude-sonnet-4-6` as the default model string in `tests/utils/mock-claude-response.ts`.

## Why
`claude-3-sonnet-20240229` is a retired model ID and is no longer consistent with the rest of the codebase which uses `claude-sonnet-4-6`. Mock data should reflect current model IDs to avoid confusion when reading test output or tracing failures.

## Scope
Single-line change in a test utility. No production code or test assertions affected.

## Tested
All 116 CLI tests pass. Root-level tests pass.